### PR TITLE
Fixing on_voice_member_disconnect exception when member is None

### DIFF
--- a/discord/ext/voice_recv/extras/speechrecognition.py
+++ b/discord/ext/voice_recv/extras/speechrecognition.py
@@ -150,7 +150,8 @@ else:
 
         @AudioSink.listener()
         def on_voice_member_disconnect(self, member: Member, ssrc: Optional[int]) -> None:
-            self._drop(member.id)
+            if member is not None:
+                self._drop(member.id)
 
         def cleanup(self) -> None:
             for user_id in tuple(self._stream_data.keys()):


### PR DESCRIPTION
Occasionally receiving `AttributeError: 'NoneType' object has no attribute 'id'` errors when an empty member is passed to the `on_voice_member_disconnect` function.