### PR TITLE
fix: stabilize DAVE receive path for Discord 2026/03 update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,5 @@ dmypy.json
 
 .vscode/
 *.code-*
+.idea
+.codex

--- a/README.md
+++ b/README.md
@@ -25,6 +25,18 @@ Naturally, this extension depends on `discord.py` being installed with voice sup
 ## Example
 See the [example script](examples/recv.py).
 
+A slash-command based traffic test example is also available at [examples/recv.py](examples/recv.py).
+
+```bash
+export DISCORD_BOT_TOKEN=your_bot_token
+export DISCORD_GUILD_ID=your_guild_id
+# Optional: capture voice WS events to JSONL
+# export VOICE_RECV_DEBUG_WS_PATH=/tmp/voice_ws_<guild_id>.jsonl
+python examples/recv.py
+```
+
+The test script writes per-speaker WAV files and periodically logs receive diagnostics.
+
 ## Feature overview
 ### Custom VoiceProtocol client
 No monkey patching or bizarre hacks required.  Simply use the library feature to use `VoiceRecvClient` as the voice client class.  See [Usage](#usage).
@@ -58,11 +70,12 @@ voice_client = await voice_channel.connect(cls=voice_recv.VoiceRecvClient)
 
 ### New voice client functions
 ```python
-def listen(sink: voice_recv.AudioSink, *, after=None) -> None
+def listen(sink: voice_recv.AudioSink, *, after=None, debug_ws_path: str | None = None) -> None
 ```
 Receives audio data into an `AudioSink`.  A sink is similar to the `AudioSource` class, where most of the logic is done in a single callback function, but in reverse.  Sinks are explained in detail in the [Sinks](#sinks) section below.
 
 The finalizer, `after` is called after the sink has been exhausted or an error occurred.  The callback signature is the same as the after callback for `play()`, one parameter for an optional Exception object.
+`debug_ws_path` is optional and enables voice WS JSONL capture only when provided.
 
 ```python
 def is_listening() -> bool

--- a/discord/ext/voice_recv/__init__.py
+++ b/discord/ext/voice_recv/__init__.py
@@ -6,6 +6,7 @@ from .sinks import *
 from .video import *
 from .opus import *
 from .rtp import *
+from .dave import *
 from .enums import *
 
 from . import (

--- a/discord/ext/voice_recv/buffer.py
+++ b/discord/ext/voice_recv/buffer.py
@@ -217,10 +217,22 @@ class HeapJitterBuffer(BaseBuffer[PacketT]):
         popped and the currently held next packet.  Returns 0 otherwise.
         """
 
-        if self._buffer and self._last_tx_seq > 0:
+        if self._buffer and self._last_tx_seq >= 0:
             return gap_wrapped(self._last_tx_seq, self._buffer[0].sequence)
 
         return 0
+
+    def advance(self, count: int = 1) -> None:
+        """
+        Advance the internal transmitted sequence without consuming a packet.
+        Used when the caller emits synthetic concealment frames.
+        """
+
+        if count < 1 or self._last_tx_seq < 0:
+            return
+
+        self._last_tx_seq = add_wrapped(self._last_tx_seq, count)
+        self._update_has_item()
 
     def flush(self) -> List[AudioPacket]:
         """

--- a/discord/ext/voice_recv/dave.py
+++ b/discord/ext/voice_recv/dave.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+__all__ = (
+    'DaveSupplemental',
+    'parse_dave_payload',
+)
+
+_DAVE_MARKER = b'\xfa\xfa'
+
+
+@dataclass(frozen=True)
+class DaveSupplemental:
+    supplemental_size: int
+    supplemental_start: int
+    nonce: int
+    ranges: tuple[tuple[int, int], ...]
+    ciphertext_len: int
+
+    @property
+    def ranges_count(self) -> int:
+        return len(self.ranges)
+
+
+def parse_dave_payload(payload: bytes) -> Optional[DaveSupplemental]:
+    if len(payload) < 2 or payload[-2:] != _DAVE_MARKER:
+        return None
+    if len(payload) <= 10:
+        return None
+
+    supplemental_size = payload[-3]
+    if supplemental_size > len(payload) or supplemental_size <= 10:
+        return None
+
+    supplemental_start = len(payload) - supplemental_size
+    nonce_start = supplemental_start + 8
+    supplemental_end = len(payload) - 3
+    if nonce_start > supplemental_end:
+        return None
+
+    try:
+        nonce, cursor = _read_uleb128(payload, nonce_start, supplemental_end)
+    except ValueError:
+        return None
+
+    ranges: list[tuple[int, int]] = []
+    while cursor < supplemental_end:
+        try:
+            offset, cursor = _read_uleb128(payload, cursor, supplemental_end)
+            size, cursor = _read_uleb128(payload, cursor, supplemental_end)
+        except ValueError:
+            return None
+        ranges.append((offset, size))
+
+    ciphertext_len = len(payload) - supplemental_size
+    if ciphertext_len <= 0:
+        return None
+
+    return DaveSupplemental(
+        supplemental_size=supplemental_size,
+        supplemental_start=supplemental_start,
+        nonce=nonce,
+        ranges=tuple(ranges),
+        ciphertext_len=ciphertext_len,
+    )
+
+def _read_uleb128(buf: bytes, start: int, end: int) -> tuple[int, int]:
+    shift = 0
+    value = 0
+    index = start
+
+    while index < end and shift <= 63:
+        byte = buf[index]
+        index += 1
+        value |= (byte & 0x7F) << shift
+        if (byte & 0x80) == 0:
+            return value, index
+        shift += 7
+
+    raise ValueError("invalid_uleb128")

--- a/discord/ext/voice_recv/gateway.py
+++ b/discord/ext/voice_recv/gateway.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import struct
 
 from discord.enums import SpeakingState, try_enum
 
@@ -21,7 +22,7 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 
-# https://cdn.discordapp.com/attachments/381887113391505410/1094473412623204533/image.png
+# https://docs.discord.com/developers/topics/opcodes-and-status-codes#voice
 # fmt: off
 IDENTIFY                  = 0
 SELECT_PROTOCOL           = 1
@@ -43,7 +44,73 @@ CHANNEL_OPTIONS_UPDATE    = 17 # (dead)
 FLAGS                     = 18
 SPEED_TEST                = 19 # (dead)
 PLATFORM                  = 20
+DAVE_PREPARE_TRANSITION        = 21
+DAVE_EXECUTE_TRANSITION        = 22
+DAVE_TRANSITION_READY          = 23
+DAVE_PREPARE_EPOCH             = 24
+MLS_EXTERNAL_SENDER            = 25
+MLS_KEY_PACKAGE                = 26
+MLS_PROPOSALS                  = 27
+MLS_COMMIT_WELCOME             = 28
+MLS_ANNOUNCE_COMMIT_TRANSITION = 29
+MLS_WELCOME                    = 30
+MLS_INVALID_COMMIT_WELCOME     = 31
 # fmt: on
+
+DAVE_AND_MLS_OPCODES = frozenset(
+    {
+        DAVE_PREPARE_TRANSITION,
+        DAVE_EXECUTE_TRANSITION,
+        DAVE_TRANSITION_READY,
+        DAVE_PREPARE_EPOCH,
+        MLS_EXTERNAL_SENDER,
+        MLS_KEY_PACKAGE,
+        MLS_PROPOSALS,
+        MLS_COMMIT_WELCOME,
+        MLS_ANNOUNCE_COMMIT_TRANSITION,
+        MLS_WELCOME,
+        MLS_INVALID_COMMIT_WELCOME,
+    }
+)
+
+_BINARY_HOOK_PATCHED = False
+
+
+def install_binary_ws_hook() -> None:
+    global _BINARY_HOOK_PATCHED
+    if _BINARY_HOOK_PATCHED:
+        return
+
+    from discord.gateway import DiscordVoiceWebSocket
+
+    original = DiscordVoiceWebSocket.received_binary_message
+    if getattr(original, "__voice_recv_binary_hook__", False):
+        _BINARY_HOOK_PATCHED = True
+        return
+
+    async def wrapped(self: DiscordVoiceWebSocket, msg: bytes):  # type: ignore[misc]
+        op = -1
+        seq = None
+        body = b""
+
+        if len(msg) >= 3:
+            seq = struct.unpack_from(">H", msg, 0)[0]
+            op = msg[2]
+            body = msg[3:]
+
+        vc = getattr(getattr(self, "_connection", None), "voice_client", None)
+        cb = getattr(vc, "_update_voice_ws_binary_state", None) if vc is not None else None
+        if op >= 0 and callable(cb):
+            try:
+                cb(op, body, seq=seq, raw_len=len(msg))
+            except Exception:
+                log.exception("Failed to capture voice websocket binary event: op=%s", op)
+
+        return await original(self, msg)
+
+    setattr(wrapped, "__voice_recv_binary_hook__", True)
+    DiscordVoiceWebSocket.received_binary_message = wrapped
+    _BINARY_HOOK_PATCHED = True
 
 
 async def hook(self: DiscordVoiceWebSocket, msg: Dict[str, Any]):
@@ -61,6 +128,8 @@ async def hook(self: DiscordVoiceWebSocket, msg: Dict[str, Any]):
             m.pop('op')
             m.pop('d')
             log.info("WS payload has extra keys: %s", m)
+
+    vc._update_voice_ws_state(op, data, raw_message=msg)
 
     if op == self.READY:
         vc._add_ssrc(vc.guild.me.id, data['ssrc'])
@@ -93,6 +162,7 @@ async def hook(self: DiscordVoiceWebSocket, msg: Dict[str, Any]):
         vc._add_ssrc(uid, data['audio_ssrc'])
         member = vc.guild.get_member(uid)
         streams = VoiceVideoStreams(data=cast('VoiceVideoPayload', data), vc=vc)
+        vc._update_video_ssrcs(uid, streams)
         vc.dispatch("voice_member_video", member, streams)
 
     elif op == CLIENT_DISCONNECT:
@@ -120,3 +190,6 @@ async def hook(self: DiscordVoiceWebSocket, msg: Dict[str, Any]):
             member,
             try_enum(VoicePlatform, data['platform']) if data['platform'] is not None else None,
         )
+
+    elif op in DAVE_AND_MLS_OPCODES:
+        vc.dispatch("voice_dave_opcode", op, data)

--- a/discord/ext/voice_recv/opus.py
+++ b/discord/ext/voice_recv/opus.py
@@ -10,7 +10,7 @@ from .buffer import HeapJitterBuffer as JitterBuffer
 from .rtp import FakePacket
 from .utils import add_wrapped
 
-from discord.opus import Decoder
+from discord.opus import Decoder, OpusError
 
 if TYPE_CHECKING:
     from typing import Optional, Tuple, Dict, Callable, Any
@@ -61,6 +61,64 @@ class PacketDecoder:
     def sink(self) -> AudioSink:
         return self.router.sink
 
+    def _stats_inc(self, key: str, value: int = 1) -> None:
+        stats = getattr(self.router.reader, 'analysis_stats', None)
+        if stats:
+            stats.inc(key, value)
+
+    def _stats_add_pcm(self, pcm_len: int) -> None:
+        stats = getattr(self.router.reader, 'analysis_stats', None)
+        if stats:
+            stats.add_pcm(pcm_len)
+
+    def _stats_add_opus_probe(
+        self,
+        *,
+        payload: bytes,
+        frames: Optional[int],
+        samples_per_frame: Optional[int],
+        frame_size: Optional[int],
+        header_ok: bool,
+        packet: AudioPacket,
+    ) -> None:
+        stats = getattr(self.router.reader, 'analysis_stats', None)
+        if stats:
+            stats.add_opus_probe(
+                ssrc=self.ssrc,
+                seq=packet.sequence,
+                ts=packet.timestamp,
+                payload_len=len(payload),
+                frames=frames,
+                samples_per_frame=samples_per_frame,
+                frame_size=frame_size,
+                header_ok=header_ok,
+            )
+
+    def _stats_add_decode_error_sample(
+        self,
+        *,
+        stage: str,
+        packet: AudioPacket,
+        payload: bytes,
+        frames: Optional[int],
+        samples_per_frame: Optional[int],
+        frame_size: Optional[int],
+        exc: Exception,
+    ) -> None:
+        stats = getattr(self.router.reader, 'analysis_stats', None)
+        if stats:
+            stats.add_decode_error_sample(
+                stage=stage,
+                ssrc=self.ssrc,
+                seq=packet.sequence,
+                ts=packet.timestamp,
+                payload=payload,
+                frames=frames,
+                samples_per_frame=samples_per_frame,
+                frame_size=frame_size,
+                exc_text=str(exc),
+            )
+
     def _get_user(self, user_id: int) -> Optional[User]:
         vc: VoiceRecvClient = self.sink.voice_client  # type: ignore
         return vc.guild.get_member(user_id) or vc.client.get_user(user_id)
@@ -105,19 +163,13 @@ class PacketDecoder:
         packet = self._buffer.pop(timeout=timeout)
 
         if packet is None:
-            # Gets the last (buffered) packet out (i think)
-            # TODO: revist this, might be an issue
             if self._buffer:
-                packets = self._buffer.flush()
-                if any(packets[1:]):
-                    log.warning(
-                        "%s packets were lost being flushed in decoder-%s\n --> (last=%s) %s",
-                        len(packets) - 1,
-                        self.ssrc,
-                        self._last_seq,
-                        [p.sequence for p in packets],
-                    )
-                return packets[0]
+                # If the next packet is not sequential yet, emit one synthetic
+                # packet and advance the jitter buffer cursor for PLC/FEC flow.
+                if self._buffer.gap() > 0:
+                    self._buffer.advance()
+                    self._stats_inc('jitter_synthetic_packets')
+                    return self._make_fakepacket()
             return
         elif not packet:
             packet = self._make_fakepacket()
@@ -151,7 +203,59 @@ class PacketDecoder:
 
         # Decode as per usual
         if packet:
-            pcm = self._decoder.decode(packet.decrypted_data, fec=False)
+            ext = getattr(packet, 'extension_data', None)
+            if isinstance(ext, dict) and ext.get('_voice_recv_needs_dave_inner_decrypt'):
+                self._stats_inc('dave_inner_decode_skipped')
+                self._stats_add_pcm(0)
+                return packet, b''
+
+            payload: bytes = packet.decrypted_data or b''
+            frames: Optional[int] = None
+            samples_per_frame: Optional[int] = None
+            frame_size: Optional[int] = None
+            header_ok = True
+            try:
+                frames = self._decoder.packet_get_nb_frames(payload)
+                samples_per_frame = self._decoder.packet_get_samples_per_frame(payload)
+                if frames <= 0 or samples_per_frame <= 0:
+                    header_ok = False
+                else:
+                    frame_size = frames * samples_per_frame
+            except Exception:
+                header_ok = False
+
+            self._stats_add_opus_probe(
+                payload=payload,
+                frames=frames,
+                samples_per_frame=samples_per_frame,
+                frame_size=frame_size,
+                header_ok=header_ok,
+                packet=packet,
+            )
+            try:
+                pcm = self._decoder.decode(payload, fec=False)
+                self._stats_inc('opus_decode_ok')
+            except OpusError as exc:
+                log.debug(
+                    "Opus decode failed for ssrc=%s seq=%s ts=%s: %s",
+                    self.ssrc,
+                    packet.sequence,
+                    packet.timestamp,
+                    exc,
+                )
+                # Keep pipeline alive when payload is still DAVE-wrapped or frame is damaged.
+                pcm = b''
+                self._stats_inc('opus_decode_err')
+                self._stats_add_decode_error_sample(
+                    stage='decode',
+                    packet=packet,
+                    payload=payload,
+                    frames=frames,
+                    samples_per_frame=samples_per_frame,
+                    frame_size=frame_size,
+                    exc=exc,
+                )
+            self._stats_add_pcm(len(pcm))
             return packet, pcm
 
         # Fake packet, need to check next one to use fec
@@ -165,10 +269,48 @@ class PacketDecoder:
                 packet.sequence,
                 next_packet.sequence,
             )
-            pcm = self._decoder.decode(nextdata, fec=True)
+            try:
+                pcm = self._decoder.decode(nextdata, fec=True)
+                self._stats_inc('opus_fec_ok')
+            except OpusError as exc:
+                log.debug(
+                    "Opus FEC decode failed for ssrc=%s fake_seq=%s next_seq=%s: %s",
+                    self.ssrc,
+                    packet.sequence,
+                    next_packet.sequence,
+                    exc,
+                )
+                pcm = b''
+                self._stats_inc('opus_fec_err')
+                self._stats_add_decode_error_sample(
+                    stage='fec',
+                    packet=packet,
+                    payload=nextdata,
+                    frames=None,
+                    samples_per_frame=None,
+                    frame_size=None,
+                    exc=exc,
+                )
 
         # Need to drop a packet
         else:
-            pcm = self._decoder.decode(None, fec=False)
+            try:
+                pcm = self._decoder.decode(None, fec=False)
+                self._stats_inc('opus_plc_ok')
+            except OpusError as exc:
+                log.debug("Opus PLC decode failed for ssrc=%s seq=%s: %s", self.ssrc, packet.sequence, exc)
+                pcm = b''
+                self._stats_inc('opus_plc_err')
+                self._stats_add_decode_error_sample(
+                    stage='plc',
+                    packet=packet,
+                    payload=b'',
+                    frames=None,
+                    samples_per_frame=None,
+                    frame_size=None,
+                    exc=exc,
+                )
+
+        self._stats_add_pcm(len(pcm))
 
         return packet, pcm

--- a/discord/ext/voice_recv/reader.py
+++ b/discord/ext/voice_recv/reader.py
@@ -837,7 +837,13 @@ class AudioReader:
                 self.analysis_stats.inc('rtcp_packets_total')
                 self.analysis_stats.inc(f'rtcp_type_{packet.type}')
 
-                if not isinstance(packet, rtp.ReceiverReportPacket):
+                # RFC 3550 defines RTCP PT=200 as Sender Report (SR) and
+                # PT=201 as Receiver Report (RR) (see RFC 3550 section 6.4).
+                # Compound RTCP traffic is expected to begin with SR or RR
+                # (section 6.1), so both are treated as normal baseline
+                # control-plane packets here.
+                # Only non-SR/RR RTCP classes are logged as unexpected/noisy.
+                if not isinstance(packet, (rtp.ReceiverReportPacket, rtp.SenderReportPacket)):
                     self._log_unexpected_rtcp_packet(packet, packet_data)
         except CryptoError as e:
             log.error("CryptoError decoding packet data")

--- a/discord/ext/voice_recv/reader.py
+++ b/discord/ext/voice_recv/reader.py
@@ -3,15 +3,25 @@
 from __future__ import annotations
 
 import time
+import json
+import os
 import logging
 import threading
+from dataclasses import dataclass
 
+from collections import defaultdict, deque
 from operator import itemgetter
 from typing import TYPE_CHECKING
 
 from . import rtp
+from .dave import parse_dave_payload
 from .sinks import AudioSink
 from .router import PacketRouter, SinkEventRouter
+
+try:
+    import davey
+except ImportError:
+    davey = None
 
 try:
     import nacl.secret
@@ -40,8 +50,465 @@ __all__ = [
 ]
 
 
+@dataclass
+class PendingInnerPacket:
+    packet: 'RTPPacket'
+    payload: bytes
+    reason: str
+    queued_at: float
+    attempts: int = 0
+
+
+@dataclass
+class PendingUnknownPacket:
+    packet: 'RTPPacket'
+    queued_at: float
+
+
+class ReceiveAnalysisStats:
+    def __init__(self, *, ws_jsonl_path: str = ""):
+        self._lock = threading.Lock()
+        self._ws_jsonl_lock = threading.Lock()
+        self._counters: dict[str, int] = defaultdict(int)
+        self._max_samples = 20
+        self._max_non_audio_samples = 64
+        self._decode_err_samples: list[Dict[str, Any]] = []
+        self._dave_unhandled_samples: list[Dict[str, Any]] = []
+        self._non_audio_rtp_samples: list[Dict[str, Any]] = []
+        self._dave_nonce_last: dict[int, int] = {}
+        self._dave_seq_last: dict[int, int] = {}
+        self._voice_ws_recent_events: list[Dict[str, Any]] = []
+        self._max_ws_recent = 64
+        self._voice_ws_jsonl_path = ws_jsonl_path.strip()
+        if self._voice_ws_jsonl_path:
+            parent = os.path.dirname(self._voice_ws_jsonl_path)
+            if parent:
+                os.makedirs(parent, exist_ok=True)
+
+    def inc(self, key: str, value: int = 1) -> None:
+        if value == 0:
+            return
+        with self._lock:
+            self._counters[key] += value
+
+    def _append_sample(self, target: list[Dict[str, Any]], item: Dict[str, Any]) -> None:
+        if len(target) >= self._max_samples:
+            return
+        target.append(item)
+
+    @staticmethod
+    def _append_ring_sample(target: list[Dict[str, Any]], item: Dict[str, Any], *, maxlen: int) -> None:
+        if maxlen < 1:
+            return
+        if len(target) >= maxlen:
+            del target[0 : len(target) - maxlen + 1]
+        target.append(item)
+
+    @staticmethod
+    def _wrapped_delta(current: int, last: int, *, wrap: int) -> int:
+        raw = (current - last) % wrap
+        if raw > (wrap // 2):
+            return raw - wrap
+        return raw
+
+    def _ws_context_unlocked(self) -> Dict[str, Any]:
+        if not self._voice_ws_recent_events:
+            return {}
+
+        tail = self._voice_ws_recent_events[-5:]
+        return {
+            'ws_total': self._counters.get('voice_ws_total', 0),
+            'ws_last_op': tail[-1].get('op'),
+            'ws_recent_ops': [item.get('op') for item in tail],
+            'dave_ws_total': self._counters.get('dave_ws_total', 0),
+            'dave_ws_last_op': self._counters.get('dave_ws_last_op', -1),
+        }
+
+    @staticmethod
+    def _to_jsonable(value: Any) -> Any:
+        if value is None or isinstance(value, (str, int, float, bool)):
+            return value
+        if isinstance(value, dict):
+            return {str(k): ReceiveAnalysisStats._to_jsonable(v) for k, v in value.items()}
+        if isinstance(value, (list, tuple)):
+            return [ReceiveAnalysisStats._to_jsonable(v) for v in value]
+        return repr(value)
+
+    def _append_ws_jsonl(self, event: Dict[str, Any], event_index: int) -> None:
+        if not self._voice_ws_jsonl_path:
+            return
+
+        payload = {
+            'index': event_index,
+            'ts_unix_ms': int(event.get('ts_unix_ms', int(time.time() * 1000))),
+            'transport': event.get('transport', 'json'),
+            'op': event.get('op'),
+            'd': self._to_jsonable(event.get('d', {})),
+            'extra': self._to_jsonable(event.get('extra', {})),
+        }
+
+        try:
+            line = json.dumps(payload, ensure_ascii=False, separators=(',', ':')) + '\n'
+            with self._ws_jsonl_lock:
+                with open(self._voice_ws_jsonl_path, 'a', encoding='utf-8') as fp:
+                    fp.write(line)
+            self.inc('voice_ws_jsonl_write_ok')
+        except Exception:
+            self.inc('voice_ws_jsonl_write_err')
+
+    def add_voice_ws_event(self, event: Dict[str, Any]) -> None:
+        interesting_keys = (
+            'seq',
+            'transition_id',
+            'epoch',
+            'generation',
+            'generation_qualifier',
+            'protocol_version',
+            'group_id',
+            'ssrc',
+            'audio_ssrc',
+            'video_ssrc',
+            'user_id',
+        )
+        op = int(event.get('op', -1))
+        data = event.get('d')
+        payload = data if isinstance(data, dict) else {}
+        extra = event.get('extra')
+        extras = extra if isinstance(extra, dict) else {}
+        transport = str(event.get('transport', 'json'))
+
+        event_index = 0
+        with self._lock:
+            self._counters['voice_ws_total'] += 1
+            self._counters[f'voice_ws_transport_{transport}'] += 1
+            self._counters[f'voice_ws_op_{op}'] += 1
+            self._counters['voice_ws_last_op'] = op
+            event_index = self._counters['voice_ws_total']
+
+            item: Dict[str, Any] = {
+                'transport': transport,
+                'op': op,
+                'keys': sorted(str(k) for k in payload.keys())[:16],
+            }
+            seq = extras.get('seq')
+            if isinstance(seq, int):
+                item['seq'] = seq
+
+            for key in interesting_keys:
+                value = payload.get(key, extras.get(key))
+                if isinstance(value, (str, int, float, bool)) or value is None:
+                    if value is not None:
+                        item[key] = value
+            if transport == 'binary':
+                raw_len = extras.get('raw_len')
+                payload_len = extras.get('payload_len')
+                if isinstance(raw_len, int):
+                    item['raw_len'] = raw_len
+                if isinstance(payload_len, int):
+                    item['payload_len'] = payload_len
+
+            self._voice_ws_recent_events.append(item)
+            if len(self._voice_ws_recent_events) > self._max_ws_recent:
+                self._voice_ws_recent_events = self._voice_ws_recent_events[-self._max_ws_recent :]
+
+            if 21 <= op <= 31:
+                self._counters['dave_ws_total'] += 1
+                self._counters[f'dave_ws_transport_{transport}'] += 1
+                self._counters[f'dave_ws_op_{op}'] += 1
+                self._counters['dave_ws_last_op'] = op
+
+        self._append_ws_jsonl(event, event_index)
+
+    def add_non_audio_rtp_packet(
+        self,
+        *,
+        kind: str,
+        ssrc: int,
+        seq: int,
+        ts: int,
+        payload_type: int,
+        packet_len: int,
+        known_user: bool,
+        extended: bool,
+    ) -> None:
+        with self._lock:
+            self._counters['rtp_non_audio_packets_total'] += 1
+            self._counters[f'rtp_non_audio_{kind}_packets'] += 1
+            self._counters[f'rtp_non_audio_payload_type_{payload_type}'] += 1
+
+            item: Dict[str, Any] = {
+                'kind': kind,
+                'ssrc': ssrc,
+                'seq': seq,
+                'ts': ts,
+                'payload_type': payload_type,
+                'packet_len': packet_len,
+                'known_user': known_user,
+                'extended': extended,
+            }
+            item.update(self._ws_context_unlocked())
+            self._append_ring_sample(self._non_audio_rtp_samples, item, maxlen=self._max_non_audio_samples)
+
+    def add_pcm(self, pcm_len: int) -> None:
+        with self._lock:
+            self._counters['pcm_frames'] += 1
+            self._counters['pcm_bytes_total'] += pcm_len
+            if pcm_len == 0:
+                self._counters['pcm_empty'] += 1
+            if pcm_len not in (0, 3840):
+                self._counters['pcm_non_20ms'] += 1
+
+    def add_dave_nonce(self, ssrc: int, seq: int, nonce: int) -> None:
+        with self._lock:
+            last_nonce = self._dave_nonce_last.get(ssrc)
+            last_seq = self._dave_seq_last.get(ssrc)
+            if last_nonce is None:
+                self._counters['dave_nonce_first'] += 1
+            else:
+                nonce_delta = nonce - last_nonce
+                seq_delta = self._wrapped_delta(seq, last_seq, wrap=2**16) if last_seq is not None else 0
+
+                if last_seq is not None:
+                    if seq_delta == 1:
+                        self._counters['dave_seq_delta1'] += 1
+                    elif seq_delta > 1:
+                        self._counters['dave_seq_gap_events'] += 1
+                        self._counters['dave_seq_gap_total'] += seq_delta - 1
+                    else:
+                        self._counters['dave_seq_rewind_events'] += 1
+
+                if nonce_delta == 1:
+                    self._counters['dave_nonce_delta1'] += 1
+                elif nonce_delta > 1:
+                    self._counters['dave_nonce_gap_events'] += 1
+                    self._counters['dave_nonce_gap_total'] += nonce_delta - 1
+                    item: Dict[str, Any] = {
+                        'kind': 'dave_nonce_gap',
+                        'ssrc': ssrc,
+                        'seq': seq,
+                        'last_nonce': last_nonce,
+                        'nonce': nonce,
+                        'delta': nonce_delta,
+                        'seq_delta': seq_delta,
+                    }
+                    item.update(self._ws_context_unlocked())
+                    self._append_sample(
+                        self._dave_unhandled_samples,
+                        item,
+                    )
+                else:
+                    self._counters['dave_nonce_rewind_events'] += 1
+                    item = {
+                        'kind': 'dave_nonce_rewind',
+                        'ssrc': ssrc,
+                        'seq': seq,
+                        'last_nonce': last_nonce,
+                        'nonce': nonce,
+                        'delta': nonce_delta,
+                        'seq_delta': seq_delta,
+                    }
+                    item.update(self._ws_context_unlocked())
+                    self._append_sample(
+                        self._dave_unhandled_samples,
+                        item,
+                    )
+
+                if last_seq is not None and nonce_delta != seq_delta:
+                    self._counters['dave_nonce_seq_mismatch_events'] += 1
+                    item = {
+                        'kind': 'dave_nonce_seq_mismatch',
+                        'ssrc': ssrc,
+                        'seq': seq,
+                        'last_seq': last_seq,
+                        'seq_delta': seq_delta,
+                        'last_nonce': last_nonce,
+                        'nonce': nonce,
+                        'nonce_delta': nonce_delta,
+                    }
+                    item.update(self._ws_context_unlocked())
+                    self._append_sample(self._dave_unhandled_samples, item)
+
+            self._dave_nonce_last[ssrc] = nonce
+            self._dave_seq_last[ssrc] = seq
+
+    def add_dave_unhandled_sample(
+        self,
+        *,
+        reason: str,
+        ssrc: int,
+        seq: int,
+        ts: int,
+        payload_len: int,
+        has_marker: bool,
+        ciphertext_len: Optional[int] = None,
+        ranges_count: Optional[int] = None,
+    ) -> None:
+        with self._lock:
+            item: Dict[str, Any] = {
+                'kind': 'dave_unhandled',
+                'reason': reason,
+                'ssrc': ssrc,
+                'seq': seq,
+                'ts': ts,
+                'payload_len': payload_len,
+                'has_marker': has_marker,
+                'ciphertext_len': ciphertext_len,
+                'ranges_count': ranges_count,
+            }
+            item.update(self._ws_context_unlocked())
+            self._append_sample(
+                self._dave_unhandled_samples,
+                item,
+            )
+
+    def add_opus_probe(
+        self,
+        *,
+        ssrc: int,
+        seq: int,
+        ts: int,
+        payload_len: int,
+        frames: Optional[int],
+        samples_per_frame: Optional[int],
+        frame_size: Optional[int],
+        header_ok: bool,
+    ) -> None:
+        with self._lock:
+            self._counters['opus_probe_total'] += 1
+            bucket = self._len_bucket(payload_len)
+            self._counters[f'opus_len_bucket_{bucket}'] += 1
+            if header_ok:
+                self._counters['opus_probe_header_ok'] += 1
+            else:
+                self._counters['opus_probe_header_err'] += 1
+                self._append_sample(
+                    self._decode_err_samples,
+                    {
+                        'stage': 'probe',
+                        'ssrc': ssrc,
+                        'seq': seq,
+                        'ts': ts,
+                        'payload_len': payload_len,
+                        'frames': frames,
+                        'samples_per_frame': samples_per_frame,
+                        'frame_size': frame_size,
+                        'reason': 'invalid_opus_header',
+                    },
+                )
+            if isinstance(frames, int):
+                self._counters[f'opus_probe_frames_{frames}'] += 1
+            if isinstance(samples_per_frame, int):
+                self._counters[f'opus_probe_spf_{samples_per_frame}'] += 1
+            if isinstance(frame_size, int):
+                self._counters[f'opus_probe_frame_size_{frame_size}'] += 1
+
+    def add_decode_error_sample(
+        self,
+        *,
+        stage: str,
+        ssrc: int,
+        seq: int,
+        ts: int,
+        payload: bytes,
+        frames: Optional[int],
+        samples_per_frame: Optional[int],
+        frame_size: Optional[int],
+        exc_text: str,
+    ) -> None:
+        with self._lock:
+            item: Dict[str, Any] = {
+                'stage': stage,
+                'ssrc': ssrc,
+                'seq': seq,
+                'ts': ts,
+                'payload_len': len(payload),
+                'head_hex': payload[:8].hex(),
+                'tail_hex': payload[-8:].hex() if payload else '',
+                'frames': frames,
+                'samples_per_frame': samples_per_frame,
+                'frame_size': frame_size,
+                'exc': exc_text,
+            }
+            item.update(self._ws_context_unlocked())
+            self._append_sample(
+                self._decode_err_samples,
+                item,
+            )
+
+    @staticmethod
+    def _len_bucket(payload_len: int) -> str:
+        if payload_len <= 3:
+            return 'le3'
+        if payload_len <= 20:
+            return '4_20'
+        if payload_len <= 40:
+            return '21_40'
+        if payload_len <= 80:
+            return '41_80'
+        if payload_len <= 120:
+            return '81_120'
+        if payload_len <= 160:
+            return '121_160'
+        if payload_len <= 240:
+            return '161_240'
+        return 'gt240'
+
+    def snapshot(self) -> Dict[str, Any]:
+        with self._lock:
+            counters = dict(self._counters)
+            decode_err_samples = list(self._decode_err_samples)
+            dave_unhandled_samples = list(self._dave_unhandled_samples)
+            non_audio_rtp_samples = list(self._non_audio_rtp_samples)
+            voice_ws_recent_events = list(self._voice_ws_recent_events)
+
+        pcm_frames = counters.get('pcm_frames', 0)
+        decode_ok = counters.get('opus_decode_ok', 0)
+        decode_err = counters.get('opus_decode_err', 0)
+        decode_total = decode_ok + decode_err
+
+        counters['pcm_avg_bytes'] = round(counters.get('pcm_bytes_total', 0) / pcm_frames, 2) if pcm_frames else 0.0
+        counters['opus_decode_err_ratio'] = round((decode_err / decode_total), 4) if decode_total else 0.0
+        counters['decode_err_sample_count'] = len(decode_err_samples)
+        counters['dave_unhandled_sample_count'] = len(dave_unhandled_samples)
+        counters['non_audio_rtp_sample_count'] = len(non_audio_rtp_samples)
+        counters['voice_ws_recent_event_count'] = len(voice_ws_recent_events)
+        counters['voice_ws_jsonl_path'] = self._voice_ws_jsonl_path
+        if voice_ws_recent_events:
+            counters['voice_ws_recent_ops'] = [
+                item['op'] for item in voice_ws_recent_events[-10:] if isinstance(item.get('op'), int)
+            ]
+            counters['voice_ws_last_event'] = voice_ws_recent_events[-1]
+        else:
+            counters['voice_ws_recent_ops'] = []
+            counters['voice_ws_last_event'] = {}
+
+        dave_ws_recent_events = [item for item in voice_ws_recent_events if 21 <= int(item.get('op', -1)) <= 31]
+        counters['dave_ws_recent_event_count'] = len(dave_ws_recent_events)
+        if dave_ws_recent_events:
+            counters['dave_ws_recent_ops'] = [
+                item['op'] for item in dave_ws_recent_events[-10:] if isinstance(item.get('op'), int)
+            ]
+            counters['dave_ws_last_event'] = dave_ws_recent_events[-1]
+        else:
+            counters['dave_ws_recent_ops'] = []
+            counters['dave_ws_last_event'] = {}
+        counters['decode_err_samples'] = decode_err_samples
+        counters['dave_unhandled_samples'] = dave_unhandled_samples
+        counters['non_audio_rtp_samples'] = non_audio_rtp_samples
+        counters['voice_ws_recent_events'] = voice_ws_recent_events
+        counters['dave_ws_recent_events'] = dave_ws_recent_events
+        return counters
+
+
 class AudioReader:
-    def __init__(self, sink: AudioSink, voice_client: VoiceRecvClient, *, after: Optional[AfterCB] = None):
+    def __init__(
+        self,
+        sink: AudioSink,
+        voice_client: VoiceRecvClient,
+        *,
+        after: Optional[AfterCB] = None,
+        ws_jsonl_path: str = "",
+    ):
         if after is not None and not callable(after):
             raise TypeError('Expected a callable for the "after" parameter.')
 
@@ -54,11 +521,37 @@ class AudioReader:
 
         self.active: bool = False
         self.error: Optional[Exception] = None
+
+        self.analysis_stats: ReceiveAnalysisStats = ReceiveAnalysisStats(ws_jsonl_path=ws_jsonl_path)
         self.packet_router: PacketRouter = PacketRouter(sink, self)
         self.event_router: SinkEventRouter = SinkEventRouter(sink, self)
-        self.decryptor: PacketDecryptor = PacketDecryptor(voice_client.mode, bytes(voice_client.secret_key))
+        self.decryptor: PacketDecryptor = PacketDecryptor(
+            voice_client.mode,
+            bytes(voice_client.secret_key),
+            voice_client=voice_client,
+            stats=self.analysis_stats,
+        )
         self.speaking_timer: SpeakingTimer = SpeakingTimer(self)
         self.keepalive: UDPKeepAlive = UDPKeepAlive(voice_client)
+        self._unknown_ssrc_notice: set[int] = set()
+        self._unknown_ssrc_drop_count: dict[int, int] = {}
+        self._unknown_ssrc_last_info_at: dict[int, float] = {}
+        self._unknown_ssrc_last_info_count: dict[int, int] = {}
+        self._unknown_ssrc_info_every_packets = 200
+        self._unknown_ssrc_info_every_sec = 5.0
+        self._unexpected_rtcp_count: dict[tuple[int, str], int] = {}
+        self._unexpected_rtcp_last_info_at: dict[tuple[int, str], float] = {}
+        self._unexpected_rtcp_last_info_count: dict[tuple[int, str], int] = {}
+        self._unexpected_rtcp_info_every_packets = 200
+        self._unexpected_rtcp_info_every_sec = 5.0
+        self._pending_unknown_packets: dict[int, deque[PendingUnknownPacket]] = defaultdict(deque)
+        self._pending_unknown_lock = threading.Lock()
+        self._pending_unknown_max_per_ssrc = 32
+        self._pending_unknown_max_age_sec = 0.5
+        if ws_jsonl_path:
+            log.info("Voice WS capture enabled: path=%s", ws_jsonl_path)
+        else:
+            log.info("Voice WS capture disabled")
 
     def is_listening(self) -> bool:
         return self.active
@@ -104,6 +597,7 @@ class AudioReader:
 
         self.speaking_timer.stop()
         self.keepalive.stop()
+        self.decryptor.close()
 
         if self.after:
             try:
@@ -133,18 +627,218 @@ class AudioReader:
     def _is_ip_discovery_packet(self, data: bytes) -> bool:
         return len(data) == 74 and data[1] == 0x02
 
+    def _log_unexpected_rtcp_packet(self, packet: 'rtp.RTCPPacket', packet_data: bytes) -> None:
+        packet_type = int(packet.type)
+        packet_class = type(packet).__name__
+        key = (packet_type, packet_class)
+        now = time.monotonic()
+
+        total = self._unexpected_rtcp_count.get(key, 0) + 1
+        self._unexpected_rtcp_count[key] = total
+
+        last_info_at = self._unexpected_rtcp_last_info_at.get(key)
+        last_info_count = self._unexpected_rtcp_last_info_count.get(key, 0)
+
+        if last_info_at is None:
+            self._unexpected_rtcp_last_info_at[key] = now
+            self._unexpected_rtcp_last_info_count[key] = total
+            log.info(
+                "Received unexpected rtcp packet: type=%s class=%s delta=%s total=%s",
+                packet_type,
+                packet_class,
+                1,
+                total,
+            )
+            log.debug("Unexpected RTCP packet detail: packet=%s data=%s", packet, packet_data)
+            return
+
+        should_log_info = (
+            total - last_info_count >= self._unexpected_rtcp_info_every_packets
+            or now - last_info_at >= self._unexpected_rtcp_info_every_sec
+        )
+        if should_log_info:
+            delta = total - last_info_count
+            window_sec = now - last_info_at
+            rate = (delta / window_sec) if window_sec > 0 else 0.0
+            self._unexpected_rtcp_last_info_at[key] = now
+            self._unexpected_rtcp_last_info_count[key] = total
+            log.info(
+                "Still receiving unexpected rtcp packet: type=%s class=%s delta=%s total=%s window_sec=%.2f rate=%.2f/s",
+                packet_type,
+                packet_class,
+                delta,
+                total,
+                window_sec,
+                rate,
+            )
+        else:
+            log.debug(
+                "Unexpected rtcp packet: type=%s class=%s total=%s packet=%s",
+                packet_type,
+                packet_class,
+                total,
+                packet,
+            )
+
+    def _expire_pending_unknown_locked(self, now: float) -> None:
+        for ssrc, queue in list(self._pending_unknown_packets.items()):
+            while queue and now - queue[0].queued_at > self._pending_unknown_max_age_sec:
+                queue.popleft()
+                self.analysis_stats.inc('unknown_ssrc_expired')
+            if not queue:
+                del self._pending_unknown_packets[ssrc]
+
+    def _flush_pending_unknown_for_ssrc(self, ssrc: int) -> list['RTPPacket']:
+        now = time.monotonic()
+        with self._pending_unknown_lock:
+            self._expire_pending_unknown_locked(now)
+            queue = self._pending_unknown_packets.pop(ssrc, None)
+            if not queue:
+                return []
+            return [item.packet for item in queue]
+
+    def _queue_pending_unknown_packet(self, packet: RTPPacket) -> None:
+        now = time.monotonic()
+        with self._pending_unknown_lock:
+            self._expire_pending_unknown_locked(now)
+            queue = self._pending_unknown_packets[packet.ssrc]
+            queue.append(PendingUnknownPacket(packet=packet, queued_at=now))
+            self.analysis_stats.inc('unknown_ssrc_queued')
+            while len(queue) > self._pending_unknown_max_per_ssrc:
+                queue.popleft()
+                self.analysis_stats.inc('unknown_ssrc_overflow')
+
+    def flush_pending_unknown_for_ssrc(self, ssrc: int) -> None:
+        packets = self._flush_pending_unknown_for_ssrc(ssrc)
+        if not packets:
+            return
+
+        for packet in packets:
+            media_kind = self.voice_client._get_ssrc_media_kind(packet.ssrc)
+            if media_kind != 'audio':
+                self.analysis_stats.inc('unknown_ssrc_flushed_non_audio')
+                continue
+            self.analysis_stats.inc('unknown_ssrc_flushed')
+            self.speaking_timer.notify(packet.ssrc)
+            self.packet_router.feed_rtp(packet)
+
+    def _route_rtp_packet(self, rtp_packet: RTPPacket) -> None:
+        ssrc = rtp_packet.ssrc
+
+        if ssrc in self.voice_client._ssrc_to_id:
+            self._unknown_ssrc_notice.discard(ssrc)
+            self._unknown_ssrc_drop_count.pop(ssrc, None)
+            self._unknown_ssrc_last_info_at.pop(ssrc, None)
+            self._unknown_ssrc_last_info_count.pop(ssrc, None)
+
+            pending_packets = self._flush_pending_unknown_for_ssrc(ssrc)
+            for packet in pending_packets:
+                media_kind = self.voice_client._get_ssrc_media_kind(packet.ssrc)
+                if media_kind != 'audio':
+                    self.analysis_stats.inc('unknown_ssrc_flushed_non_audio')
+                    continue
+                self.analysis_stats.inc('unknown_ssrc_flushed')
+                self.speaking_timer.notify(packet.ssrc)
+                self.packet_router.feed_rtp(packet)
+
+        if ssrc not in self.voice_client._ssrc_to_id:
+            self.analysis_stats.inc('rtp_unknown_ssrc_dropped')
+            if rtp_packet.is_silence():
+                self.analysis_stats.inc('rtp_unknown_ssrc_silence_dropped')
+                return
+
+            media_kind = self.voice_client._get_ssrc_media_kind(ssrc)
+            if media_kind == 'unknown':
+                self._queue_pending_unknown_packet(rtp_packet)
+
+            drop_count = self._unknown_ssrc_drop_count.get(ssrc, 0) + 1
+            self._unknown_ssrc_drop_count[ssrc] = drop_count
+            now = time.monotonic()
+            payload_size = len(rtp_packet.data)
+
+            if ssrc not in self._unknown_ssrc_notice:
+                self._unknown_ssrc_notice.add(ssrc)
+                self._unknown_ssrc_last_info_at[ssrc] = now
+                self._unknown_ssrc_last_info_count[ssrc] = drop_count
+                log.info(
+                    "Received packet for unknown ssrc=%s kind=%s dropped=%s seq=%s ts=%s payload=%s",
+                    ssrc,
+                    media_kind,
+                    drop_count,
+                    rtp_packet.sequence,
+                    rtp_packet.timestamp,
+                    payload_size,
+                )
+            else:
+                last_info_at = self._unknown_ssrc_last_info_at.get(ssrc, 0.0)
+                last_info_count = self._unknown_ssrc_last_info_count.get(ssrc, 0)
+                should_log_info = (
+                    drop_count - last_info_count >= self._unknown_ssrc_info_every_packets
+                    or now - last_info_at >= self._unknown_ssrc_info_every_sec
+                )
+                if should_log_info:
+                    self._unknown_ssrc_last_info_at[ssrc] = now
+                    self._unknown_ssrc_last_info_count[ssrc] = drop_count
+                    log.info(
+                        "Still receiving unknown ssrc=%s kind=%s dropped=%s last_seq=%s last_ts=%s payload=%s",
+                        ssrc,
+                        media_kind,
+                        drop_count,
+                        rtp_packet.sequence,
+                        rtp_packet.timestamp,
+                        payload_size,
+                    )
+                else:
+                    log.debug(
+                        "Received packet for unknown ssrc=%s kind=%s dropped=%s seq=%s",
+                        ssrc,
+                        media_kind,
+                        drop_count,
+                        rtp_packet.sequence,
+                    )
+            return
+
+        self.speaking_timer.notify(ssrc)
+        self.packet_router.feed_rtp(rtp_packet)
+
     def callback(self, packet_data: bytes) -> None:
         packet = rtp_packet = rtcp_packet = None
+        recovered_rtp_packets: list[RTPPacket] = []
+        defer_current_rtp = False
         try:
             if not rtp.is_rtcp(packet_data):
                 packet = rtp_packet = rtp.decode_rtp(packet_data)
+                media_kind = self.voice_client._get_ssrc_media_kind(packet.ssrc)
+                self.analysis_stats.inc('rtp_media_packets_total')
+                self.analysis_stats.inc(f'rtp_media_{media_kind}_packets')
+
+                if media_kind in ('video', 'screen', 'rtx', 'test'):
+                    self.analysis_stats.add_non_audio_rtp_packet(
+                        kind=media_kind,
+                        ssrc=packet.ssrc,
+                        seq=packet.sequence,
+                        ts=packet.timestamp,
+                        payload_type=packet.payload,
+                        packet_len=len(packet_data),
+                        known_user=(self.voice_client._get_id_from_ssrc(packet.ssrc) is not None),
+                        extended=packet.extended,
+                    )
+                    return
+
                 packet.decrypted_data = self.decryptor.decrypt_rtp(packet)
+                self.analysis_stats.inc('rtp_packets_total')
+                self.analysis_stats.inc(f'rtp_payload_type_{packet.payload}')
+                recovered_rtp_packets = self.decryptor.pop_recovered_rtp_packets()
+                defer_current_rtp = self.decryptor.is_deferred_packet(packet)
+                if any(recovered is packet for recovered in recovered_rtp_packets):
+                    defer_current_rtp = True
             else:
                 packet = rtcp_packet = rtp.decode_rtcp(self.decryptor.decrypt_rtcp(packet_data))
+                self.analysis_stats.inc('rtcp_packets_total')
+                self.analysis_stats.inc(f'rtcp_type_{packet.type}')
 
                 if not isinstance(packet, rtp.ReceiverReportPacket):
-                    log.info("Received unexpected rtcp packet: type=%s, %s", packet.type, type(packet))
-                    log.debug("Packet info:\n  packet=%s\n  data=%s", packet, packet_data)
+                    self._log_unexpected_rtcp_packet(packet, packet_data)
         except CryptoError as e:
             log.error("CryptoError decoding packet data")
             log.debug("CryptoError details:\n  data=%s\n  secret_key=%s", packet_data, self.voice_client.secret_key)
@@ -156,30 +850,25 @@ class AudioReader:
 
             log.exception("Error unpacking packet")
             log.debug("Packet data: len=%s data=%s", len(packet_data), packet_data)
-        finally:
-            if self.error:
-                self.stop()
-                return
-            if not packet:
-                return
+
+        if self.error:
+            self.stop()
+            return
+        if not packet:
+            return
 
         if rtcp_packet:
             self.packet_router.feed_rtcp(rtcp_packet)
         elif rtp_packet:
-            ssrc = rtp_packet.ssrc
-
-            if ssrc not in self.voice_client._ssrc_to_id:
-                if rtp_packet.is_silence():
-                    # TODO: buffer packets from unknown ssrcs, 50 max?
-                    # also remove this log later its pointless
-                    log.debug("Skipping silence packet for unknown ssrc %s", ssrc)
-                    return
-                else:
-                    log.info("Received packet for unknown ssrc %s:\n%s", ssrc, rtp_packet)
-
-            self.speaking_timer.notify(ssrc)
             try:
-                self.packet_router.feed_rtp(rtp_packet)
+                for recovered in recovered_rtp_packets:
+                    self._route_rtp_packet(recovered)
+
+                if defer_current_rtp:
+                    self.analysis_stats.inc('dave_inner_defer_current_skipped')
+                    return
+
+                self._route_rtp_packet(rtp_packet)
             except Exception as e:
                 log.exception('Error processing rtp packet')
                 self.error = e
@@ -194,7 +883,14 @@ class PacketDecryptor:
         'xsalsa20_poly1305',
     ]
 
-    def __init__(self, mode: SupportedModes, secret_key: bytes) -> None:
+    def __init__(
+        self,
+        mode: SupportedModes,
+        secret_key: bytes,
+        *,
+        voice_client: Optional[VoiceRecvClient] = None,
+        stats: Optional[ReceiveAnalysisStats] = None,
+    ) -> None:
         self.mode: SupportedModes = mode
         try:
             self.decrypt_rtp: DecryptRTP = getattr(self, '_decrypt_rtp_' + mode)
@@ -203,6 +899,14 @@ class PacketDecryptor:
             raise NotImplementedError(mode) from e
 
         self.box: EncryptionBox = self._make_box(secret_key)
+        self._voice_client = voice_client
+        self._stats = stats
+        self._dave_audio_strip_logged: bool = False
+        self._pending_inner_packets: dict[int, list[PendingInnerPacket]] = defaultdict(list)
+        self._pending_inner_ready: list[RTPPacket] = []
+        self._pending_inner_max_per_ssrc = 128
+        self._pending_inner_max_attempts = 16
+        self._pending_inner_max_age_sec = 2.5
 
     def _make_box(self, secret_key: bytes) -> EncryptionBox:
         if self.mode.startswith("aead"):
@@ -212,6 +916,237 @@ class PacketDecryptor:
 
     def update_secret_key(self, secret_key: bytes) -> None:
         self.box = self._make_box(secret_key)
+
+    def close(self) -> None:
+        return
+
+    def _inc(self, key: str, value: int = 1) -> None:
+        if self._stats:
+            self._stats.inc(key, value)
+
+    def _add_dave_nonce(self, *, ssrc: int, seq: int, nonce: int) -> None:
+        if self._stats:
+            self._stats.add_dave_nonce(ssrc, seq, nonce)
+
+    def _add_dave_unhandled_sample(
+        self,
+        *,
+        reason: str,
+        packet: RTPPacket,
+        payload_len: int,
+        has_marker: bool,
+        ciphertext_len: Optional[int] = None,
+        ranges_count: Optional[int] = None,
+    ) -> None:
+        if self._stats:
+            self._stats.add_dave_unhandled_sample(
+                reason=reason,
+                ssrc=packet.ssrc,
+                seq=packet.sequence,
+                ts=packet.timestamp,
+                payload_len=payload_len,
+                has_marker=has_marker,
+                ciphertext_len=ciphertext_len,
+                ranges_count=ranges_count,
+            )
+
+    @staticmethod
+    def _is_retryable_inner_reason(reason: str) -> bool:
+        return reason in {
+            'no_session',
+            'session_not_ready',
+            'no_user_id',
+            'decrypt_error',
+        }
+
+    def _defer_pending_inner_packet(
+        self,
+        *,
+        packet: RTPPacket,
+        payload: bytes,
+        reason: str,
+        ranges_count: int,
+    ) -> None:
+        queue = self._pending_inner_packets[packet.ssrc]
+        queue.append(
+            PendingInnerPacket(
+                packet=packet,
+                payload=bytes(payload),
+                reason=reason,
+                queued_at=time.monotonic(),
+            )
+        )
+
+        packet.extension_data['_voice_recv_pending_inner_decrypt'] = True
+        packet.extension_data['_voice_recv_needs_dave_inner_decrypt'] = True
+        packet.extension_data['_voice_recv_dave_ranges_count'] = ranges_count
+
+        self._inc('dave_inner_defer_queued')
+        self._inc(f'dave_inner_defer_reason_{reason}')
+
+        if len(queue) <= self._pending_inner_max_per_ssrc:
+            return
+
+        dropped = queue.pop(0)
+        dropped.packet.extension_data['_voice_recv_pending_inner_decrypt'] = False
+        dropped.packet.extension_data['_voice_recv_needs_dave_inner_decrypt'] = True
+        self._inc('dave_inner_defer_drop_overflow')
+        self._add_dave_unhandled_sample(
+            reason='inner_defer_overflow',
+            packet=dropped.packet,
+            payload_len=len(dropped.payload),
+            has_marker=True,
+            ranges_count=dropped.packet.extension_data.get('_voice_recv_dave_ranges_count'),
+        )
+
+    def _drain_pending_inner_packets(self) -> None:
+        if not self._pending_inner_packets:
+            return
+
+        now = time.monotonic()
+        for ssrc, queue in list(self._pending_inner_packets.items()):
+            kept: list[PendingInnerPacket] = []
+            for pending in queue:
+                age = now - pending.queued_at
+                if age > self._pending_inner_max_age_sec:
+                    pending.packet.extension_data['_voice_recv_pending_inner_decrypt'] = False
+                    self._inc('dave_inner_defer_drop_expired')
+                    self._add_dave_unhandled_sample(
+                        reason='inner_defer_expired',
+                        packet=pending.packet,
+                        payload_len=len(pending.payload),
+                        has_marker=True,
+                        ranges_count=pending.packet.extension_data.get('_voice_recv_dave_ranges_count'),
+                    )
+                    continue
+
+                plain, reason = self._try_dave_inner_decrypt(
+                    pending.packet,
+                    pending.payload,
+                    emit_error_sample=False,
+                )
+                if plain is not None:
+                    pending.packet.decrypted_data = plain
+                    pending.packet.extension_data['_voice_recv_pending_inner_decrypt'] = False
+                    pending.packet.extension_data['_voice_recv_needs_dave_inner_decrypt'] = False
+                    pending.packet.extension_data['_voice_recv_dave_ranges_count'] = 0
+                    pending.packet.extension_data['_voice_recv_dave_inner_deferred_recovered'] = True
+                    self._pending_inner_ready.append(pending.packet)
+                    self._inc('dave_inner_defer_recovered')
+                    continue
+
+                pending.attempts += 1
+                retryable = self._is_retryable_inner_reason(reason)
+                if retryable and pending.attempts < self._pending_inner_max_attempts:
+                    kept.append(pending)
+                    continue
+
+                pending.packet.extension_data['_voice_recv_pending_inner_decrypt'] = False
+                if retryable:
+                    self._inc('dave_inner_defer_drop_attempts')
+                    drop_reason = 'inner_defer_drop_attempts'
+                else:
+                    self._inc('dave_inner_defer_drop_unrecoverable')
+                    drop_reason = f'inner_defer_drop_{reason}'
+                self._add_dave_unhandled_sample(
+                    reason=drop_reason,
+                    packet=pending.packet,
+                    payload_len=len(pending.payload),
+                    has_marker=True,
+                    ranges_count=pending.packet.extension_data.get('_voice_recv_dave_ranges_count'),
+                )
+
+            if kept:
+                self._pending_inner_packets[ssrc] = kept
+            else:
+                del self._pending_inner_packets[ssrc]
+
+    def pop_recovered_rtp_packets(self) -> list[RTPPacket]:
+        self._drain_pending_inner_packets()
+        if not self._pending_inner_ready:
+            return []
+
+        ready = self._pending_inner_ready
+        self._pending_inner_ready = []
+        return ready
+
+    @staticmethod
+    def is_deferred_packet(packet: RTPPacket) -> bool:
+        return bool(packet.extension_data.get('_voice_recv_pending_inner_decrypt'))
+
+    def _try_dave_inner_decrypt(
+        self,
+        packet: RTPPacket,
+        payload: bytes,
+        *,
+        emit_error_sample: bool = True,
+    ) -> tuple[Optional[bytes], str]:
+        if davey is None:
+            self._inc('dave_inner_decrypt_no_davey')
+            return None, 'no_davey'
+
+        if self._voice_client is None:
+            self._inc('dave_inner_decrypt_no_voice_client')
+            return None, 'no_voice_client'
+
+        state = getattr(self._voice_client, '_connection', None)
+        session = getattr(state, 'dave_session', None)
+        if session is None:
+            self._inc('dave_inner_decrypt_no_session')
+            return None, 'no_session'
+
+        if not getattr(session, 'ready', False):
+            self._inc('dave_inner_decrypt_session_not_ready')
+            return None, 'session_not_ready'
+
+        user_id = self._voice_client._get_id_from_ssrc(packet.ssrc)
+        if user_id is None:
+            self._inc('dave_inner_decrypt_no_user_id')
+            return None, 'no_user_id'
+
+        try:
+            decrypted = session.decrypt(int(user_id), davey.MediaType.audio, bytes(payload))
+            decrypted_bytes = bytes(decrypted)
+        except Exception as exc:
+            self._inc('dave_inner_decrypt_err')
+            if emit_error_sample:
+                self._add_dave_unhandled_sample(
+                    reason='inner_decrypt_error',
+                    packet=packet,
+                    payload_len=len(payload),
+                    has_marker=True,
+                )
+            log.debug(
+                "DAVE inner decrypt failed: ssrc=%s user_id=%s seq=%s ts=%s err=%s",
+                packet.ssrc,
+                user_id,
+                packet.sequence,
+                packet.timestamp,
+                exc,
+            )
+            return None, 'decrypt_error'
+
+        self._inc('dave_inner_decrypt_ok')
+        packet.extension_data['_voice_recv_dave_inner_decrypted'] = True
+        packet.extension_data['_voice_recv_needs_dave_inner_decrypt'] = False
+        packet.extension_data['_voice_recv_pending_inner_decrypt'] = False
+        return decrypted_bytes, 'ok'
+
+    def _decrypt_rtp_transport_aead_xchacha20_poly1305_rtpsize(self, packet: RTPPacket) -> bytes:
+        packet.adjust_rtpsize()
+
+        nonce = bytearray(24)
+        nonce[:4] = packet.nonce
+        voice_data = packet.data
+
+        assert isinstance(self.box, nacl.secret.Aead)
+        result = self.box.decrypt(bytes(voice_data), bytes(packet.header), bytes(nonce))
+
+        if packet.extended:
+            offset = packet.update_ext_headers(result)
+            result = result[offset:]
+
+        return result
 
     def _decrypt_rtp_xsalsa20_poly1305(self, packet: RTPPacket) -> bytes:
         nonce = bytearray(24)
@@ -270,19 +1205,89 @@ class PacketDecryptor:
         return header + result
 
     def _decrypt_rtp_aead_xchacha20_poly1305_rtpsize(self, packet: RTPPacket) -> bytes:
-        packet.adjust_rtpsize()
+        result = self._decrypt_rtp_transport_aead_xchacha20_poly1305_rtpsize(packet)
 
-        nonce = bytearray(24)
-        nonce[:4] = packet.nonce
-        voice_data = packet.data
+        has_marker = len(result) >= 2 and result[-2:] == b'\xfa\xfa'
+        parsed = parse_dave_payload(result)
 
-        # Blob vomit
-        assert isinstance(self.box, nacl.secret.Aead)
-        result = self.box.decrypt(bytes(voice_data), bytes(packet.header), bytes(nonce))
+        if has_marker:
+            self._inc('dave_marker_packets')
 
-        if packet.extended:
-            offset = packet.update_ext_headers(result)
-            result = result[offset:]
+        if parsed:
+            self._inc('dave_parse_ok')
+            self._add_dave_nonce(ssrc=packet.ssrc, seq=packet.sequence, nonce=parsed.nonce)
+            packet.extension_data['_voice_recv_needs_dave_inner_decrypt'] = True
+            packet.extension_data['_voice_recv_pending_inner_decrypt'] = False
+            packet.extension_data['_voice_recv_dave_nonce'] = parsed.nonce
+            packet.extension_data['_voice_recv_dave_ranges_count'] = parsed.ranges_count
+            self._inc('dave_needs_inner_decrypt_packets')
+
+            inner_plain, inner_reason = self._try_dave_inner_decrypt(packet, result)
+            if inner_plain is not None:
+                packet.extension_data['_voice_recv_dave_ranges_count'] = 0
+                return inner_plain
+
+            if parsed.ranges_count == 0 and 0 < parsed.ciphertext_len <= len(result):
+                result = result[:parsed.ciphertext_len]
+                packet.extension_data['_voice_recv_needs_dave_inner_decrypt'] = False
+                packet.extension_data['_voice_recv_dave_ranges_count'] = 0
+                self._inc('dave_strip_success')
+                if not self._dave_audio_strip_logged:
+                    self._dave_audio_strip_logged = True
+                    log.info(
+                        "DAVE audio strip enabled: marker detected, trimming supplemental trailer before Opus decode"
+                    )
+            else:
+                self._inc('dave_inner_unresolved_packets')
+                if parsed.ranges_count > 0:
+                    self._inc('dave_ranges_nonzero')
+                    if self._is_retryable_inner_reason(inner_reason):
+                        self._defer_pending_inner_packet(
+                            packet=packet,
+                            payload=result,
+                            reason=inner_reason,
+                            ranges_count=parsed.ranges_count,
+                        )
+                        self._inc('dave_ranges_nonzero_deferred')
+                        self._add_dave_unhandled_sample(
+                            reason=f'ranges_nonzero_deferred_{inner_reason}',
+                            packet=packet,
+                            payload_len=len(result),
+                            has_marker=has_marker,
+                            ciphertext_len=parsed.ciphertext_len,
+                            ranges_count=parsed.ranges_count,
+                        )
+                    else:
+                        self._add_dave_unhandled_sample(
+                            reason=f'ranges_nonzero_{inner_reason}',
+                            packet=packet,
+                            payload_len=len(result),
+                            has_marker=has_marker,
+                            ciphertext_len=parsed.ciphertext_len,
+                            ranges_count=parsed.ranges_count,
+                        )
+                else:
+                    self._add_dave_unhandled_sample(
+                        reason=f'invalid_ciphertext_len_{inner_reason}',
+                        packet=packet,
+                        payload_len=len(result),
+                        has_marker=has_marker,
+                        ciphertext_len=parsed.ciphertext_len,
+                        ranges_count=parsed.ranges_count,
+                    )
+                self._inc('dave_strip_unhandled')
+        else:
+            if has_marker:
+                self._inc('dave_parse_fail')
+                self._inc('dave_strip_unhandled')
+                self._add_dave_unhandled_sample(
+                    reason='parse_fail',
+                    packet=packet,
+                    payload_len=len(result),
+                    has_marker=has_marker,
+                )
+            else:
+                self._inc('dave_non_marker_packets')
 
         return result
 
@@ -295,7 +1300,6 @@ class PacketDecryptor:
         result = self.box.decrypt(data[8:-4], bytes(header), bytes(nonce))
 
         return header + result
-
 
 class SpeakingTimer(threading.Thread):
     def __init__(self, reader: AudioReader):

--- a/discord/ext/voice_recv/rtp.py
+++ b/discord/ext/voice_recv/rtp.py
@@ -228,15 +228,24 @@ class RTPPacket(_PacketCmpMixin):
             data = self.header[-4:] + data
 
         # data is the decrypted packet payload containing the extension header and opus data
+        if len(data) < 4:
+            self.extension = self._ext_header(b'', 0, ())
+            return 0
+
         profile, length = struct.unpack_from('>2sH', data)
 
         if profile == self._ext_magic:
             self._parse_bede_header(data, length)
 
-        values = struct.unpack('>%sI' % length, data[4 : 4 + length * 4])
-        self.extension = self._ext_header(profile, length, values)
+        max_words = max((len(data) - 4) // 4, 0)
+        safe_length = min(length, max_words)
+        if safe_length > 0:
+            values = struct.unpack('>%sI' % safe_length, data[4 : 4 + safe_length * 4])
+        else:
+            values = ()
+        self.extension = self._ext_header(profile, safe_length, values)
 
-        offset = 4 + length * 4
+        offset = 4 + safe_length * 4
         if self._rtpsize:
             # remove the extra offset from adding the header in
             offset -= 4
@@ -249,7 +258,12 @@ class RTPPacket(_PacketCmpMixin):
         n = 0
 
         while n < length:
+            if offset >= len(data):
+                break
+
             next_byte = data[offset : offset + 1]
+            if not next_byte:
+                break
 
             if next_byte == b'\x00':
                 offset += 1
@@ -259,9 +273,12 @@ class RTPPacket(_PacketCmpMixin):
 
             element_id = header >> 4
             element_len = 1 + (header & 0b0000_1111)
+            end = offset + 1 + element_len
+            if end > len(data):
+                break
 
-            self.extension_data[element_id] = data[offset + 1 : offset + 1 + element_len]
-            offset += 1 + element_len
+            self.extension_data[element_id] = data[offset + 1 : end]
+            offset = end
             n += 1
 
     def _dump_info(self) -> str:

--- a/discord/ext/voice_recv/voice_client.py
+++ b/discord/ext/voice_recv/voice_client.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import time
 import asyncio
 import logging
+import base64
 
 import discord
 from discord.voice_state import VoiceConnectionState
@@ -12,14 +13,15 @@ from discord.utils import MISSING
 
 from typing import TYPE_CHECKING
 
-from .gateway import hook
+from .gateway import hook, install_binary_ws_hook, DAVE_AND_MLS_OPCODES
 from .reader import AudioReader
 from .sinks import AudioSink
 
 if TYPE_CHECKING:
-    from typing import Optional, Dict, Any, Union
+    from typing import Optional, Dict, Any, Union, Set
     from discord.ext.commands._types import CoroFunc
     from .reader import AfterCB
+    from .video import VoiceVideoStreams
 
 from pprint import pformat
 
@@ -40,9 +42,17 @@ class VoiceRecvClient(discord.VoiceClient):
         self._reader: AudioReader = MISSING
         self._ssrc_to_id: Dict[int, int] = {}
         self._id_to_ssrc: Dict[int, int] = {}
+        self._ssrc_media_kind: Dict[int, str] = {}
+        self._user_stream_ssrcs: Dict[int, Set[int]] = {}
         self._event_listeners: Dict[str, list] = {}
+        self._voice_ws_recent_ops: list[int] = []
+        self._voice_ws_last_payloads: Dict[int, Dict[str, Any]] = {}
+        self._voice_ws_pending_events: list[Dict[str, Any]] = []
+        self._dave_ws_recent_ops: list[int] = []
+        self._dave_ws_last_payloads: Dict[int, Dict[str, Any]] = {}
 
     def create_connection_state(self) -> VoiceConnectionState:
+        install_binary_ws_hook()
         return VoiceConnectionState(self, hook=hook)
 
     async def on_voice_state_update(self, data) -> None:
@@ -109,24 +119,140 @@ class VoiceRecvClient(discord.VoiceClient):
         if self._reader:
             self._reader.event_router.dispatch(event, *args, **kwargs)
 
+    def _record_voice_ws_event(self, event: Dict[str, Any]) -> None:
+        op = int(event.get('op', -1))
+        data = event.get('d')
+        payload = dict(data) if isinstance(data, dict) else {}
+
+        if op >= 0:
+            self._voice_ws_recent_ops.append(op)
+            if len(self._voice_ws_recent_ops) > 512:
+                self._voice_ws_recent_ops = self._voice_ws_recent_ops[-512:]
+            self._voice_ws_last_payloads[op] = payload
+
+            if op in DAVE_AND_MLS_OPCODES:
+                self._dave_ws_recent_ops.append(op)
+                if len(self._dave_ws_recent_ops) > 256:
+                    self._dave_ws_recent_ops = self._dave_ws_recent_ops[-256:]
+                self._dave_ws_last_payloads[op] = payload
+
+        if self._reader and hasattr(self._reader, 'analysis_stats'):
+            self._reader.analysis_stats.add_voice_ws_event(event)
+        else:
+            self._voice_ws_pending_events.append(event)
+            if len(self._voice_ws_pending_events) > 1024:
+                self._voice_ws_pending_events = self._voice_ws_pending_events[-1024:]
+
+    def _update_voice_ws_state(self, op: int, data: Dict[str, Any], *, raw_message: Optional[Dict[str, Any]] = None) -> None:
+        payload = dict(data)
+        extra: Dict[str, Any] = {}
+        if isinstance(raw_message, dict):
+            for key, value in raw_message.items():
+                if key in ('op', 'd'):
+                    continue
+                extra[key] = value
+
+        event: Dict[str, Any] = {
+            'transport': 'json',
+            'op': int(op),
+            'd': payload,
+            'extra': extra,
+            'ts_unix_ms': int(time.time() * 1000),
+        }
+        self._record_voice_ws_event(event)
+
+    def _update_voice_ws_binary_state(self, op: int, payload: bytes, *, seq: Optional[int], raw_len: int) -> None:
+        event: Dict[str, Any] = {
+            'transport': 'binary',
+            'op': int(op),
+            'd': {
+                '_binary_b64': base64.b64encode(payload).decode('ascii'),
+            },
+            'extra': {
+                'seq': seq,
+                'payload_len': len(payload),
+                'raw_len': raw_len,
+            },
+            'ts_unix_ms': int(time.time() * 1000),
+        }
+        self._record_voice_ws_event(event)
+
+    def _flush_voice_ws_pending_events(self) -> None:
+        if not self._reader or not hasattr(self._reader, 'analysis_stats'):
+            return
+        if not self._voice_ws_pending_events:
+            return
+
+        for event in self._voice_ws_pending_events:
+            self._reader.analysis_stats.add_voice_ws_event(event)
+        self._voice_ws_pending_events.clear()
+
+    def get_recv_diagnostics(self) -> Dict[str, Any]:
+        if self._reader and hasattr(self._reader, 'analysis_stats'):
+            return self._reader.analysis_stats.snapshot()
+        return {}
+
     def cleanup(self) -> None:
         # TODO: Does the order here matter?
         super().cleanup()
         self._event_listeners.clear()
         self.stop()
 
-    def _add_ssrc(self, user_id: int, ssrc: int) -> None:
-        self._ssrc_to_id[ssrc] = user_id
-        self._id_to_ssrc[user_id] = ssrc
+    def _add_ssrc(self, user_id: int, ssrc: int, *, kind: str = 'audio') -> None:
+        if not ssrc:
+            return
 
-        if self._reader:
+        self._ssrc_to_id[ssrc] = user_id
+        self._ssrc_media_kind[ssrc] = kind
+        if kind == 'audio':
+            self._id_to_ssrc[user_id] = ssrc
+
+        if kind == 'audio' and self._reader:
             self._reader.packet_router.set_user_id(ssrc, user_id)
+            self._reader.flush_pending_unknown_for_ssrc(ssrc)
+
+    def _update_video_ssrcs(self, user_id: int, streams: 'VoiceVideoStreams') -> None:
+        self._add_ssrc(user_id, streams.audio_ssrc, kind='audio')
+
+        current: set[int] = set()
+
+        if streams.video_ssrc:
+            current.add(int(streams.video_ssrc))
+            self._add_ssrc(user_id, int(streams.video_ssrc), kind='video')
+
+        for stream in streams.streams:
+            stream_ssrc = int(stream.ssrc)
+            stream_kind = stream.type if stream.type in ('video', 'screen', 'test') else 'video'
+            current.add(stream_ssrc)
+            self._add_ssrc(user_id, stream_ssrc, kind=stream_kind)
+
+            if stream.rtx_ssrc:
+                rtx_ssrc = int(stream.rtx_ssrc)
+                current.add(rtx_ssrc)
+                self._add_ssrc(user_id, rtx_ssrc, kind='rtx')
+
+        previous = self._user_stream_ssrcs.get(user_id, set())
+        for stale_ssrc in previous - current:
+            if stale_ssrc == self._id_to_ssrc.get(user_id):
+                continue
+            self._ssrc_to_id.pop(stale_ssrc, None)
+            self._ssrc_media_kind.pop(stale_ssrc, None)
+
+        self._user_stream_ssrcs[user_id] = current
 
     def _remove_ssrc(self, *, user_id: int) -> None:
         ssrc = self._id_to_ssrc.pop(user_id, None)
         if ssrc:
-            self._reader.speaking_timer.drop_ssrc(ssrc)
+            if self._reader:
+                self._reader.speaking_timer.drop_ssrc(ssrc)
             self._ssrc_to_id.pop(ssrc, None)
+            self._ssrc_media_kind.pop(ssrc, None)
+
+        for stream_ssrc in self._user_stream_ssrcs.pop(user_id, set()):
+            if stream_ssrc == ssrc:
+                continue
+            self._ssrc_to_id.pop(stream_ssrc, None)
+            self._ssrc_media_kind.pop(stream_ssrc, None)
 
     def _get_ssrc_from_id(self, user_id: int) -> Optional[int]:
         return self._id_to_ssrc.get(user_id)
@@ -134,8 +260,20 @@ class VoiceRecvClient(discord.VoiceClient):
     def _get_id_from_ssrc(self, ssrc: int) -> Optional[int]:
         return self._ssrc_to_id.get(ssrc)
 
-    def listen(self, sink: AudioSink, *, after: Optional[AfterCB] = None) -> None:
-        """Receives audio into a :class:`AudioSink`."""
+    def _get_ssrc_media_kind(self, ssrc: int) -> str:
+        return self._ssrc_media_kind.get(ssrc, 'unknown')
+
+    def listen(
+        self,
+        sink: AudioSink,
+        *,
+        after: Optional[AfterCB] = None,
+        debug_ws_path: Optional[str] = None,
+    ) -> None:
+        """Receives audio into a :class:`AudioSink`.
+
+        If ``debug_ws_path`` is provided, voice WS events are mirrored to JSONL.
+        """
         # TODO: more info
 
         if not self.is_connected():
@@ -147,8 +285,14 @@ class VoiceRecvClient(discord.VoiceClient):
         if self.is_listening():
             raise discord.ClientException('Already receiving audio.')
 
-        self._reader = AudioReader(sink, self, after=after)
+        self._reader = AudioReader(
+            sink,
+            self,
+            after=after,
+            ws_jsonl_path=debug_ws_path.strip() if isinstance(debug_ws_path, str) else "",
+        )
         self._reader.start()
+        self._flush_voice_ws_pending_events()
 
     def is_listening(self) -> bool:
         """Indicates if we're currently receiving audio."""

--- a/examples/recv.py
+++ b/examples/recv.py
@@ -1,47 +1,401 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import annotations
+
+import os
+import time
+import wave
+import logging
+import threading
+from collections import defaultdict
+
 import discord
+from discord import app_commands
 from discord.ext import commands, voice_recv
+
+
+def _require_env(name: str) -> str:
+    value = os.getenv(name, "").strip()
+    if not value:
+        raise RuntimeError(f"Missing required environment variable: {name}")
+    return value
+
+
+DISCORD_BOT_TOKEN = _require_env("DISCORD_BOT_TOKEN")
+DISCORD_GUILD_ID = int(_require_env("DISCORD_GUILD_ID"))
+TARGET_GUILD = discord.Object(id=DISCORD_GUILD_ID)
+VOICE_RECV_DEBUG_WS_PATH = os.getenv("VOICE_RECV_DEBUG_WS_PATH", "").strip()
+
 
 discord.opus._load_default()
 
-bot = commands.Bot(command_prefix=commands.when_mentioned, intents=discord.Intents.all())
 
-class Testing(commands.Cog):
-    def __init__(self, bot):
-        self.bot = bot
+intents = discord.Intents.default()
+intents.guilds = True
+intents.voice_states = True
+intents.members = True
 
-    @commands.command()
-    async def test(self, ctx):
+bot = commands.Bot(command_prefix=commands.when_mentioned, intents=intents)
+log = logging.getLogger("discord.ext.voice_recv.example.audio_recv_test")
+
+
+class PerUserWaveSink(voice_recv.AudioSink):
+    def __init__(self, output_dir: str, file_prefix: str, on_packet, on_stream_open):
+        super().__init__()
+        self.output_dir = output_dir
+        self.file_prefix = file_prefix
+        self._on_packet = on_packet
+        self._on_stream_open = on_stream_open
+        self._writers: dict[str, wave.Wave_write] = {}
+        self._paths: dict[str, str] = {}
+        self._lock = threading.Lock()
+        os.makedirs(self.output_dir, exist_ok=True)
+
+    def wants_opus(self) -> bool:
+        return False
+
+    def _stream_key(self, user, ssrc: int) -> str:
+        user_id = getattr(user, "id", None)
+        if user_id is not None:
+            return f"user_{int(user_id)}"
+        return f"ssrc_{ssrc}"
+
+    def _ensure_writer(self, stream_key: str) -> wave.Wave_write:
+        with self._lock:
+            writer = self._writers.get(stream_key)
+            if writer is not None:
+                return writer
+
+            output_path = os.path.join(self.output_dir, f"{self.file_prefix}_{stream_key}.wav")
+            writer = wave.open(output_path, "wb")
+            writer.setnchannels(2)
+            writer.setsampwidth(2)
+            writer.setframerate(48000)
+            self._writers[stream_key] = writer
+            self._paths[stream_key] = output_path
+
+        self._on_stream_open(stream_key, output_path)
+        return writer
+
+    def write(self, user, data: voice_recv.VoiceData) -> None:
+        self._on_packet(user, data)
+        pcm = data.pcm or b""
+        if not pcm:
+            return
+
+        stream_key = self._stream_key(user, data.packet.ssrc)
+        writer = self._ensure_writer(stream_key)
+        writer.writeframes(pcm)
+
+    def get_paths(self) -> dict[str, str]:
+        with self._lock:
+            return dict(self._paths)
+
+    def cleanup(self):
+        with self._lock:
+            writers = list(self._writers.values())
+            self._writers.clear()
+            self._paths.clear()
+
+        for writer in writers:
+            try:
+                writer.close()
+            except Exception:
+                pass
+
+
+class ReceiveTraffic(commands.Cog):
+    def __init__(self, client: commands.Bot):
+        self.bot = client
+        self._lock = threading.Lock()
+        self._packet_count = defaultdict(int)
+        self._recording_paths: dict[int, dict[str, str]] = {}
+        self._recording_patterns: dict[int, str] = {}
+        self._diag_last_emit: dict[int, float] = defaultdict(float)
+
+    def _recording_stream_open_callback(self, guild_id: int):
+        def callback(stream_key: str, output_path: str) -> None:
+            with self._lock:
+                mapping = self._recording_paths.setdefault(guild_id, {})
+                mapping[stream_key] = output_path
+
+        return callback
+
+    @staticmethod
+    def _format_recording_paths(paths: dict[str, str], *, limit: int = 6) -> str:
+        if not paths:
+            return "(No recordings created yet)"
+
+        items = sorted(paths.items(), key=lambda item: item[0])
+        preview = items[:limit]
+        lines = [f"{key}: `{path}`" for key, path in preview]
+        if len(items) > limit:
+            lines.append(f"... and {len(items) - limit} more files")
+        return "\n".join(lines)
+
+    def _get_diag(self, guild_id: int) -> dict:
+        guild = self.bot.get_guild(guild_id)
+        if guild is None:
+            return {}
+        voice_client = guild.voice_client
+        if isinstance(voice_client, voice_recv.VoiceRecvClient):
+            return voice_client.get_recv_diagnostics()
+        return {}
+
+    @staticmethod
+    def _diag_summary(diag: dict) -> str:
+        ws_recent = diag.get('voice_ws_recent_ops')
+        ws_tail = "-"
+        if isinstance(ws_recent, list) and ws_recent:
+            ws_tail = ",".join(str(op) for op in ws_recent[-5:])
+
+        return (
+            f"strip_ok={diag.get('dave_strip_success', 0)} "
+            f"parse_fail={diag.get('dave_parse_fail', 0)} "
+            f"ranges_nonzero={diag.get('dave_ranges_nonzero', 0)} "
+            f"inner_needed={diag.get('dave_needs_inner_decrypt_packets', 0)} "
+            f"inner_ok={diag.get('dave_inner_decrypt_ok', 0)} "
+            f"inner_err={diag.get('dave_inner_decrypt_err', 0)} "
+            f"inner_no_session={diag.get('dave_inner_decrypt_no_session', 0)} "
+            f"inner_no_uid={diag.get('dave_inner_decrypt_no_user_id', 0)} "
+            f"inner_no_davey={diag.get('dave_inner_decrypt_no_davey', 0)} "
+            f"inner_skipped={diag.get('dave_inner_decode_skipped', 0)} "
+            f"nonce_gap={diag.get('dave_nonce_gap_events', 0)} "
+            f"nonce_rewind={diag.get('dave_nonce_rewind_events', 0)} "
+            f"nonce_seq_mismatch={diag.get('dave_nonce_seq_mismatch_events', 0)} "
+            f"ws_total={diag.get('voice_ws_total', 0)} "
+            f"ws_json={diag.get('voice_ws_transport_json', 0)} "
+            f"ws_bin={diag.get('voice_ws_transport_binary', 0)} "
+            f"ws_last={diag.get('voice_ws_last_op', '-')} "
+            f"ws_tail={ws_tail} "
+            f"dave_ws_total={diag.get('dave_ws_total', 0)} "
+            f"dave_ws_last={diag.get('dave_ws_last_op', '-')} "
+            f"ws_jsonl_ok={diag.get('voice_ws_jsonl_write_ok', 0)} "
+            f"ws_jsonl_err={diag.get('voice_ws_jsonl_write_err', 0)} "
+            f"media_total={diag.get('rtp_media_packets_total', 0)} "
+            f"media_audio={diag.get('rtp_media_audio_packets', 0)} "
+            f"media_video={diag.get('rtp_media_video_packets', 0)} "
+            f"media_screen={diag.get('rtp_media_screen_packets', 0)} "
+            f"media_rtx={diag.get('rtp_media_rtx_packets', 0)} "
+            f"non_audio={diag.get('rtp_non_audio_packets_total', 0)} "
+            f"unknown_drop={diag.get('rtp_unknown_ssrc_dropped', 0)} "
+            f"unknown_q={diag.get('unknown_ssrc_queued', 0)} "
+            f"unknown_flush={diag.get('unknown_ssrc_flushed', 0)} "
+            f"unknown_flush_non_audio={diag.get('unknown_ssrc_flushed_non_audio', 0)} "
+            f"unknown_expired={diag.get('unknown_ssrc_expired', 0)} "
+            f"unknown_overflow={diag.get('unknown_ssrc_overflow', 0)} "
+            f"opus_probe_hdr_err={diag.get('opus_probe_header_err', 0)} "
+            f"opus_err_ratio={diag.get('opus_decode_err_ratio', 0.0)} "
+            f"pcm_avg_bytes={diag.get('pcm_avg_bytes', 0.0)} "
+            f"pcm_empty={diag.get('pcm_empty', 0)} "
+            f"err_samples={diag.get('decode_err_sample_count', 0)}"
+        )
+
+    def _packet_callback(self, guild_id: int):
         def callback(user, data: voice_recv.VoiceData):
-            print(f"Got packet from {user}")
+            now = time.time()
+            with self._lock:
+                self._packet_count[guild_id] += 1
+                count = self._packet_count[guild_id]
+                last_emit = self._diag_last_emit[guild_id]
 
-            ## voice power level, how loud the user is speaking
-            # ext_data = packet.extension_data.get(voice_recv.ExtensionID.audio_power)
-            # value = int.from_bytes(ext_data, 'big')
-            # power = 127-(value & 127)
-            # print('#' * int(power * (79/128)))
-            ## instead of 79 you can use shutil.get_terminal_size().columns-1
+            if count % 200 == 0:
+                who = getattr(user, "id", None)
+                packet = data.packet
+                log.info(
+                    "recv.diag.traffic guild=%s packets=%s user=%s ssrc=%s seq=%s ts=%s",
+                    guild_id,
+                    count,
+                    who,
+                    packet.ssrc,
+                    packet.sequence,
+                    packet.timestamp,
+                )
 
-        vc = await ctx.author.voice.channel.connect(cls=voice_recv.VoiceRecvClient)
-        vc.listen(voice_recv.BasicSink(callback))
+            if now - last_emit >= 5.0:
+                diag = self._get_diag(guild_id)
+                latest_err = None
+                err_samples = diag.get('decode_err_samples')
+                if isinstance(err_samples, list) and err_samples:
+                    latest_err = err_samples[-1]
+                non_audio_samples = diag.get('non_audio_rtp_samples')
+                latest_non_audio = None
+                if isinstance(non_audio_samples, list) and non_audio_samples:
+                    latest_non_audio = non_audio_samples[-1]
+                log.info(
+                    "recv.diag guild=%s dave_marker=%s %s",
+                    guild_id,
+                    diag.get('dave_marker_packets', 0),
+                    self._diag_summary(diag),
+                )
+                if latest_err:
+                    log.info(
+                        "recv.diag.sample guild=%s stage=%s seq=%s len=%s frames=%s spf=%s head=%s",
+                        guild_id,
+                        latest_err.get('stage'),
+                        latest_err.get('seq'),
+                        latest_err.get('payload_len'),
+                        latest_err.get('frames'),
+                        latest_err.get('samples_per_frame'),
+                        latest_err.get('head_hex'),
+                    )
+                if latest_non_audio:
+                    log.info(
+                        "recv.diag.media guild=%s kind=%s ssrc=%s seq=%s pt=%s len=%s known_user=%s",
+                        guild_id,
+                        latest_non_audio.get('kind'),
+                        latest_non_audio.get('ssrc'),
+                        latest_non_audio.get('seq'),
+                        latest_non_audio.get('payload_type'),
+                        latest_non_audio.get('packet_len'),
+                        latest_non_audio.get('known_user'),
+                    )
+                with self._lock:
+                    self._diag_last_emit[guild_id] = now
 
-    @commands.command()
-    async def stop(self, ctx):
-        await ctx.voice_client.disconnect()
+        return callback
 
-    @commands.command()
-    async def die(self, ctx):
-        ctx.voice_client.stop()
-        await ctx.bot.close()
+    @app_commands.command(name="join", description="Join your current voice channel and start receiving traffic")
+    @app_commands.guilds(TARGET_GUILD)
+    async def join(self, interaction: discord.Interaction):
+        guild = interaction.guild
+        if guild is None:
+            await interaction.response.send_message("This command can only be used in a server.", ephemeral=True)
+            return
 
-@bot.event
-async def on_ready():
-    print('Logged in as {0.id}/{0}'.format(bot.user))
-    print('------')
+        member = interaction.user
+        if not isinstance(member, discord.Member) or member.voice is None or member.voice.channel is None:
+            await interaction.response.send_message("Please join a voice channel first.", ephemeral=True)
+            return
+
+        await interaction.response.defer(ephemeral=True, thinking=True)
+        target_channel = member.voice.channel
+        voice_client = guild.voice_client
+
+        if voice_client is None:
+            voice_client = await target_channel.connect(cls=voice_recv.VoiceRecvClient)
+        elif voice_client.channel != target_channel:
+            await voice_client.move_to(target_channel)
+
+        if not isinstance(voice_client, voice_recv.VoiceRecvClient):
+            await interaction.followup.send(
+                "The active voice client is not VoiceRecvClient. Disconnect and try again.",
+                ephemeral=True,
+            )
+            return
+
+        if not voice_client.is_listening():
+            session_ts = int(time.time())
+            prefix = f"voice_recv_{guild.id}_{session_ts}"
+            pattern = f"/tmp/{prefix}_<user_or_ssrc>.wav"
+            sink = PerUserWaveSink(
+                output_dir="/tmp",
+                file_prefix=prefix,
+                on_packet=self._packet_callback(guild.id),
+                on_stream_open=self._recording_stream_open_callback(guild.id),
+            )
+            voice_client.listen(
+                sink,
+                debug_ws_path=VOICE_RECV_DEBUG_WS_PATH if VOICE_RECV_DEBUG_WS_PATH else None,
+            )
+            with self._lock:
+                self._recording_paths[guild.id] = {}
+                self._recording_patterns[guild.id] = pattern
+        else:
+            pattern = self._recording_patterns.get(guild.id)
+            existing_sink = voice_client.sink
+            if isinstance(existing_sink, PerUserWaveSink):
+                with self._lock:
+                    current = self._recording_paths.setdefault(guild.id, {})
+                    current.update(existing_sink.get_paths())
+                if pattern is None:
+                    pattern = f"{existing_sink.output_dir}/{existing_sink.file_prefix}_<user_or_ssrc>.wav"
+                    with self._lock:
+                        self._recording_patterns[guild.id] = pattern
+            if pattern is None:
+                pattern = "(unknown)"
+
+        with self._lock:
+            file_count = len(self._recording_paths.get(guild.id, {}))
+
+        diag = self._get_diag(guild.id)
+        ws_jsonl_path = diag.get('voice_ws_jsonl_path', '') or '(disabled)'
+        await interaction.followup.send(
+            f"Joined `{target_channel}` and started receiving traffic."
+            f"\nRecording pattern: `{pattern}`"
+            f"\nRecording files created: {file_count}"
+            f"\nWS JSONL: `{ws_jsonl_path}`",
+            ephemeral=True,
+        )
+
+    @app_commands.command(name="leave", description="Leave the voice channel")
+    @app_commands.guilds(TARGET_GUILD)
+    async def leave(self, interaction: discord.Interaction):
+        guild = interaction.guild
+        if guild is None or guild.voice_client is None:
+            await interaction.response.send_message("No active voice connection.", ephemeral=True)
+            return
+
+        voice_client = guild.voice_client
+        if isinstance(voice_client, voice_recv.VoiceRecvClient) and isinstance(voice_client.sink, PerUserWaveSink):
+            with self._lock:
+                current = self._recording_paths.setdefault(guild.id, {})
+                current.update(voice_client.sink.get_paths())
+
+        with self._lock:
+            output_paths = dict(self._recording_paths.get(guild.id, {}))
+            pattern = self._recording_patterns.get(guild.id, "(unknown)")
+
+        await guild.voice_client.disconnect()
+        with self._lock:
+            self._recording_paths.pop(guild.id, None)
+            self._recording_patterns.pop(guild.id, None)
+
+        await interaction.response.send_message(
+            "Left the voice channel."
+            f"\nRecording pattern: `{pattern}`"
+            f"\nRecording files created: {len(output_paths)}"
+            f"\n{self._format_recording_paths(output_paths)}",
+            ephemeral=True,
+        )
+
+    @app_commands.command(name="stats", description="Show current received packet count")
+    @app_commands.guilds(TARGET_GUILD)
+    async def stats(self, interaction: discord.Interaction):
+        guild = interaction.guild
+        if guild is None:
+            await interaction.response.send_message("This command can only be used in a server.", ephemeral=True)
+            return
+
+        with self._lock:
+            count = self._packet_count[guild.id]
+            output_paths = dict(self._recording_paths.get(guild.id, {}))
+            pattern = self._recording_patterns.get(guild.id, "(unknown)")
+        diag = self._get_diag(guild.id)
+
+        await interaction.response.send_message(
+            f"Current received packets: {count}\n"
+            f"Recording pattern: `{pattern}`\n"
+            f"Recording files created: {len(output_paths)}\n"
+            f"{self._format_recording_paths(output_paths)}\n"
+            f"WS JSONL: `{diag.get('voice_ws_jsonl_path', '') or '(disabled)'}`\n"
+            f"diag: {self._diag_summary(diag)}",
+            ephemeral=True,
+        )
+
 
 @bot.event
 async def setup_hook():
-    await bot.add_cog(Testing(bot))
+    await bot.add_cog(ReceiveTraffic(bot))
+    synced = await bot.tree.sync(guild=TARGET_GUILD)
+    log.info("recv.setup synced=%s guild=%s", len(synced), DISCORD_GUILD_ID)
 
-bot.run("token")
+
+@bot.event
+async def on_ready():
+    assert bot.user is not None
+    log.info("recv.ready user=%s user_id=%s", bot.user, bot.user.id)
+
+
+if __name__ == "__main__":
+    bot.run(DISCORD_BOT_TOKEN)


### PR DESCRIPTION
  ## Done in this PR
  - Added DAVE payload parsing/integration and safer inner-decrypt fallback handling.
  - Added SSRC media-kind routing so non-audio streams (video/screen/rtx) do not enter audio decode.
  - Added unknown-SSRC short buffering and flush-on-mapping recovery.
  - Added voice WS observability (JSON + binary) and optional `debug_ws_path` JSONL output.
  - Hardened RTP extension parsing and Opus decode error handling to avoid pipeline crashes.
  - Updated example for easier traffic testing and diagnostics.

  ## Manual validation completed
  - Single-user voice
  - Multi-user voice
  - Video enabled
  - Screen share enabled

  No crashes or pipeline breakage were observed in these scenarios.

  ## How to observe with `examples/recv.py`
  ```bash
  export DISCORD_BOT_TOKEN=your_bot_token
  export DISCORD_GUILD_ID=your_guild_id
  # Optional: write voice WS events to JSONL
  # export VOICE_RECV_DEBUG_WS_PATH=/tmp/voice_ws_<guild_id>.jsonl
  python examples/recv.py
  ```
  Then use slash commands in the target guild:

  - /join to start receive + recording
  - /stats to inspect counters/diagnostics
  - /leave to stop and print recorded output summary

  The example writes per-speaker WAV files and logs structured receive diagnostics, so DAVE/WS/RTP/Opus behavior can be observed directly.

  ## Scope note
  This is **not** a full DAVE/MLS state-machine implementation yet.

  ## Request for feedback
  Please test in your environments and share feedback/logs, especially around transition/epoch behavior and long-running sessions.

  ## Related Issues
  - Refs #53 